### PR TITLE
Remove use of anyhow in lib code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,17 @@ categories = ["asynchronous"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-anyhow = "1.0.53"
-async-bincode = "0.6.1"
-futures = "0.3.19"
-futures-core = "0.3.19"
-serde = { version = "1.0.136", features = [ "derive" ] }
-slab = "0.4.5"
-tokio = { version = "1.16.1", features = [ "full" ] }
-tokio-tower = "0.6.0"
-tower = { version = "0.4.11", features = [ "full" ] }
-tracing = "0.1.29"
+async-bincode = "0.6"
+futures = "0.3"
+futures-core = "0.3"
+serde = { version = "1", features = ["derive"] }
+slab = "0.4"
+tokio = { version = "1", features = ["full"] }
+tokio-tower = "0.6"
+tower = { version = "0.4", features = ["full"] }
+tracing = "0.1"
 
 [dev-dependencies]
-tracing-subscriber = "0.3.7"
+tracing-subscriber = "0.3"
 examples-lib = { path = "examples-lib" }
 rand = "0.8"

--- a/examples-lib/Cargo.toml
+++ b/examples-lib/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.53"
-futures = "0.3.19"
-futures-core = "0.3.19"
-pin-project-lite = "0.2.8"
-serde = { version = "1.0.136", features = [ "derive" ] }
-tokio = { version = "1.16.1", features = [ "full" ] }
-tokio-tower = "0.6.0"
-tokio-util = "0.6.9"
-tower = { version = "0.4.11", features = [ "full" ] }
-tracing = "0.1.29"
+anyhow = "1"
+futures = "0.3"
+futures-core = "0.3"
+pin-project-lite = "0.2"
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+tokio-tower = "0.6"
+tokio-util = "0.6"
+tower = { version = "0.4", features = ["full"] }
+tracing = "0.1"
 leaning-tower = { path = ".." }

--- a/examples/data_discarder_client.rs
+++ b/examples/data_discarder_client.rs
@@ -1,6 +1,7 @@
-use anyhow::Result;
 use examples_lib::data_discarder_types;
-use leaning_tower::{allocator_client::AllocatorClientService, mux_client::MuxClient};
+use leaning_tower::{
+    allocator_client::AllocatorClientService, error::Result, mux_client::MuxClient,
+};
 use rand::Rng;
 use tower::{Service, ServiceExt};
 use tracing::{error, info};
@@ -16,26 +17,14 @@ async fn discarder_call(
     service: &mut DataDiscarderService,
     request: data_discarder_types::Action,
 ) -> Result<data_discarder_types::Response> {
-    Ok(service
-        .ready()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?
-        .call(request)
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?)
+    Ok(service.ready().await?.call(request).await?)
 }
 
 async fn allocator_call(
     service: &mut DataDiscarderAllocatorService,
     request: data_discarder_types::DataDiscarderVariant,
 ) -> Result<DataDiscarderService> {
-    Ok(service
-        .ready()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?
-        .call(request)
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?)
+    Ok(service.ready().await?.call(request).await?)
 }
 
 fn random_payload() -> Vec<u8> {

--- a/examples/data_discarder_server.rs
+++ b/examples/data_discarder_server.rs
@@ -1,8 +1,7 @@
-use anyhow::Result;
-use examples_lib::data_discarder_service::DataDiscarder;
-use examples_lib::data_discarder_types::DataDiscarderVariant;
-
-use leaning_tower::{allocator::AllocatorService, mux_server};
+use examples_lib::{
+    data_discarder_service::DataDiscarder, data_discarder_types::DataDiscarderVariant,
+};
+use leaning_tower::{allocator::AllocatorService, error::Result, mux_server};
 use tracing::{error, info, Level};
 
 async fn use_forever() -> Result<()> {

--- a/examples/printer_client.rs
+++ b/examples/printer_client.rs
@@ -1,8 +1,9 @@
 use std::time::Duration;
 
-use anyhow::Result;
 use examples_lib::printer_types;
-use leaning_tower::{allocator_client::AllocatorClientService, mux_client::MuxClient};
+use leaning_tower::{
+    allocator_client::AllocatorClientService, error::Result, mux_client::MuxClient,
+};
 use tower::{Service, ServiceExt};
 use tracing::info;
 
@@ -15,26 +16,14 @@ async fn printer_call(
     service: &mut PrinterService,
     request: printer_types::Action,
 ) -> Result<printer_types::Response> {
-    Ok(service
-        .ready()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?
-        .call(request)
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?)
+    Ok(service.ready().await?.call(request).await?)
 }
 
 async fn allocator_call(
     service: &mut PrinterAllocatorService,
     request: printer_types::PrinterVariant,
 ) -> Result<PrinterService> {
-    Ok(service
-        .ready()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?
-        .call(request)
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?)
+    Ok(service.ready().await?.call(request).await?)
 }
 
 async fn use_single_resource_server() -> Result<()> {

--- a/examples/printer_server.rs
+++ b/examples/printer_server.rs
@@ -1,6 +1,5 @@
-use anyhow::Result;
 use examples_lib::{printer_service::Printer, printer_types::PrinterVariant};
-use leaning_tower::{allocator::AllocatorService, mux_server};
+use leaning_tower::{allocator::AllocatorService, error::Result, mux_server};
 use tracing::{info, Level};
 
 // Serve a single printer with colors at this endpoint.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,2 @@
+use tower::BoxError;
+pub type Result<T> = std::result::Result<T, BoxError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod allocator;
 pub mod allocator_client;
+pub mod error;
 pub mod mux_client;
 pub mod mux_server;
 pub mod resource_filter;

--- a/src/mux_server.rs
+++ b/src/mux_server.rs
@@ -4,7 +4,6 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Result;
 use async_bincode::AsyncBincodeStream;
 use futures::Future;
 use serde::{de::DeserializeOwned, Serialize};
@@ -13,7 +12,7 @@ use tokio_tower::multiplex;
 use tower::{buffer::Buffer, Service};
 use tracing::{debug, error, info};
 
-use crate::tagged;
+use crate::{error::Result, tagged};
 
 // TODO: Could be a layer? Probably more idiomatic.
 pub struct Detagger<S> {
@@ -35,9 +34,10 @@ where
     type Response = tagged::Response<S::Response>;
     type Error = S::Error;
     #[allow(clippy::type_complexity)]
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, S::Error>> + Send>>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), S::Error>> {
         self.inner.poll_ready(cx)
     }
 


### PR DESCRIPTION
Fixes #2 .

Slightly.
Users now have to deal with `BoxError` instead of `anyhow::Error`.
Propagating a user specific error type through the tower cogwheels is too hard.

Signed-off-by: Torstein Grindvik <torstein.grindvik@nordicsemi.no>